### PR TITLE
Decided to introduce a non-breaking change

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ yql-node
 A small module providing utility methods for accessing YQL API. Provides optional OAuth access helper.
 Most other node modules for YQL failed for me on large query strings so this one uses POST method.
 
+Modified to support returning json with a property called format, and a chainable constructor function.
+
 ## Installation
 
 ` npm install yql-node --save `
@@ -12,9 +14,11 @@ Most other node modules for YQL failed for me on large query strings so this one
 ## Usage
 ```javascript
   //call public endpoints out of the box by simple require
-  var yql = require('yql-node');
+  var yqlXML = require('yql-node');
+  var yql = require('yql-node').formatAsJSON();
   //or set the instance to use OAuth and non-public endpoint like this
-  var yqlWithOAuth = require('yql-node').withOAuth('CONSUMER KEY','CONSUMER SECRET');
+  var yqlWithOAuthXML = require('yql-node').withOAuth('CONSUMER KEY','CONSUMER SECRET');
+  var yqlWithOAuth = require('yql-node').formatAsJSON().withOAuth('CONSUMER KEY','CONSUMER SECRET');
   
   var query = 'select * from html where url="http://example.com"; ';
 
@@ -24,10 +28,29 @@ Most other node modules for YQL failed for me on large query strings so this one
   //so you read data straight from it
   
   yql.execute(query, function(error,response){
+    console.log("yql:");
+    console.log(response);
+  });
+  
+  yql.formatAsXML().execute(query, function(error,response){
+    console.log("yql as XML:");
     console.log(response);
   });
 
+
+  yqlXML.execute(query, function(error,response){
+    console.log("yqlXML:");
+    console.log(response);
+  });
+  yqlXML.format = 'json';
+  yqlXML.execute(query, function(error,response){
+    console.log("yqlXML as json:");
+    console.log(response);
+  });
+
+
   yqlWithOAuth.execute(query, function(error,response){
+    console.log("yqlOAuth:");
     console.log(response);
   });
 ```

--- a/index.js
+++ b/index.js
@@ -25,13 +25,13 @@ module.exports = {
       this.oauth.post('https://query.yahooapis.com/v1/yql',
 	               '',
 	               '',
-	              {q:query},
+	              {q:query,format:"json"},
                 callback);
     }else{
       //no oauth so calling public endpoint
       needle
           .post("https://query.yahooapis.com/v1/public/yql",
-           {q:query} ,
+           {q:query,format:"json"} ,
            { multipart: false },
             function(err,res){
               callback(err,res.body);

--- a/index.js
+++ b/index.js
@@ -1,41 +1,47 @@
 var OAuth = require('oauth');
 var needle = require('needle');
-
 module.exports = {
-  oauth : null,
-  //sets this instance to use oauth
-  withOAuth : function(consumer_key,consumer_secret){
-    this.oauth = new OAuth.OAuth(
-      'https://query.yahooapis.com/v1/yql/',
-      'https://query.yahooapis.com/v1/yql/',
-       consumer_key, //consumer key
-       consumer_secret, //consumer secret
-      '1.0',
-      null,
-      'HMAC-SHA1'
-    );
-    this.oauth.setClientOptions({ requestTokenHttpMethod: 'POST' });
-    //returns reference to itself for chainability
-    return this;
-  },
-  //executes a given query and fires the callback on finish
-  execute: function(query, callback){
-    if(this.oauth!=null){
-      //oauth set so call authorized endpoint
-      this.oauth.post('https://query.yahooapis.com/v1/yql',
-	               '',
-	               '',
-	              {q:query,format:"json"},
-                callback);
-    }else{
-      //no oauth so calling public endpoint
-      needle
-          .post("https://query.yahooapis.com/v1/public/yql",
-           {q:query,format:"json"} ,
-           { multipart: false },
-            function(err,res){
-              callback(err,res.body);
-            });
+    oauth: null,
+    format: null,
+    //yql-node used to output only xml, now the formatAsJSON chainloader should help.
+    withOAuth: function (consumer_key, consumer_secret) {
+        this.oauth = new OAuth.OAuth(
+          'https://query.yahooapis.com/v1/yql/',
+          'https://query.yahooapis.com/v1/yql/',
+          consumer_key, //consumer key
+          consumer_secret, //consumer secret
+          '1.0',
+          null,
+          'HMAC-SHA1'
+          );
+        this.oauth.setClientOptions({ requestTokenHttpMethod: 'POST' });
+
+        return this;
+    },
+    formatAsJSON: function () {
+        this.format = 'json';
+        return this;
+    },
+    formatAsXML: function () {
+        this.format = 'xml';
+        return this;
+    },
+
+    execute: function (query, callback) {
+        if (this.oauth != null) {
+            this.oauth.post('https://query.yahooapis.com/v1/yql',
+              '',
+              '',
+              { q: query, format: this.format || 'xml' },
+              callback);
+        } else {
+            needle
+              .post("https://query.yahooapis.com/v1/public/yql",
+                { q: query, format: this.format || 'xml' },
+                { multipart: false },
+                function (err, res) {
+                    callback(err, res.body);
+                });
+        }
     }
-  }
 }


### PR DESCRIPTION
Added "format" property, defaults to null, resulting in format=xml being sent in the request.
Added two helper chain functions: formatAsJSON, formatAsXML
## Usage

``` javascript
  var yql = require('yql-node');
  //these functions return the yql-node object
  yql.formatAsJSON();
  yql.formatAsXML();

  //alternative usage via property
  yql.format = 'json';

  // ... define and execute query...
```
